### PR TITLE
Fix the patch file for latest version of gitlab_config.rb

### DIFF
--- a/support/patches/gitlab-shell-config.rb.patch
+++ b/support/patches/gitlab-shell-config.rb.patch
@@ -1,5 +1,5 @@
 diff --git a/lib/gitlab_config.rb b/lib/gitlab_config.rb
-index ad15247..54056b7 100644
+index c97743b..712d321 100644
 --- a/lib/gitlab_config.rb
 +++ b/lib/gitlab_config.rb
 @@ -1,10 +1,11 @@
@@ -14,4 +14,4 @@ index ad15247..54056b7 100644
 +    @config = YAML.load(ERB.new(File.read(File.join(ROOT_PATH, 'config.yml'))).result)
    end
  
-   def repos_path
+   def home


### PR DESCRIPTION
The latest version of gitlab_config.rb (rev:d01eac9) has
is different and the support/patches/gitlab-shell-config.rb.patch
doesn't apply cleanly.

This causes the config.yml file to be loaded without any ERB template
modifications. Causing the entire buildpack to fail.
